### PR TITLE
Allow PRE to deploy public ip addresses

### DIFF
--- a/terraform-infra-approvals/pre-shared-infrastructure.json
+++ b/terraform-infra-approvals/pre-shared-infrastructure.json
@@ -4,7 +4,8 @@
     {"type": "azurerm_virtual_network"},
     {"type": "random_password"},
     {"type": "azurerm_windows_virtual_machine"},
-    {"type": "azurerm_network_interface"}
+    {"type": "azurerm_network_interface"},
+    {"type": "azurerm_public_ip"}
   ],
   "module_calls": []
 }


### PR DESCRIPTION
This is a temporary measure to allow a spike into VM spec to be conducted by the video editing team. The strategic plan is to lock this down and connect via dom1 wan

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
