### PR TITLE
PUB-1007 - Add missing bootstrap repo for PIP prod

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -4,3 +4,4 @@ prod:
   - repo: https://github.com/hmcts/sds-toffee-frontend.git
   - repo: https://github.com/hmcts/tax-tribunals-shared-infrastructure
   - repo: https://github.com/hmcts/pip-shared-infrastructures.git
+  - repo: https://github.com/hmcts/pip-shared-infrastructure-bootstap.git


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PUB-1007


### Change description ###
Add missing bootstrap repo for PIP prod


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
