### PR TITLE
Add null resource to whitelist

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -14,7 +14,8 @@
     {"type": "azurerm_api_management_api_operation_policy"},
     {"type": "azurerm_storage_blob"},
     {"type": "azuread_application"},
-    {"type": "random_uuid"}
+    {"type": "random_uuid"},
+    {"type": "null_resource"}
   ],
   "module_calls": [
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-queue?ref=master"},


### PR DESCRIPTION
### Change description ###
We need the null_resource tf resource so we can run AZ CLI commands in the terraform.
this is our current requirement: https://github.com/hmcts/pip-shared-infrastructures/pull/21

added to global for others to use.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
