### PR TITLE
Moved boostrap to resources section

### DIFF
--- a/terraform-infra-approvals/libragob-shared-infrastructure.json
+++ b/terraform-infra-approvals/libragob-shared-infrastructure.json
@@ -9,11 +9,11 @@
     {"type": "azurerm_subnet_network_security_group_association"},
     {"type": "azurerm_subnet_route_table_association"},
     {"type": "tls_private_key"},
-    {"type": "azurerm_virtual_machine_extension"}
+    {"type": "azurerm_virtual_machine_extension"},
+    {"type": "azurerm_virtual_machine_bootstrap"}    
   ],
   "module_calls": [
     {"source":  "git@github.com:hmcts/oracle-azure-infrastructure-terraform-modules.git//azure-vm?ref=0.0.56"},
-    {"source":  "git@github.com:hmcts/libragob-shared-infrastructure.git"},
-    {"source":  "git@github.com/hmcts/terraform-module-vm-bootstrap"}
+    {"source":  "git@github.com:hmcts/libragob-shared-infrastructure.git"}
   ]
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-8398


### Change description ###
Moved bootstrap resource to resources section due to a mapping error thrown by Jenkins.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
