### PR TITLE
DTSPO-8169 - enable role assignments in toffee shared infra repo

### DIFF
--- a/terraform-infra-approvals/sds-toffee-shared-infrastructure.json
+++ b/terraform-infra-approvals/sds-toffee-shared-infrastructure.json
@@ -1,0 +1,7 @@
+{
+  "resources": [
+    {"type": "azurerm_role_assignment"}
+  ],
+  "module_calls": []
+}
+


### PR DESCRIPTION
### Change description ###
This allows a role assignment to be made in the toffee shared infra repo. Need to give permission to the toffee and keda mi's to servicebus that the recipe receiver uses.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
