### PR TITLE
Fix flexible server repo

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -41,7 +41,7 @@
     {"source":  "git@github.com:hmcts/cnp-module-application-insights?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-app-service-plan?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-metric-alert?ref=master"},
-    {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible.git?ref=master"},
+    {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=master"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=adding-postgresql-ad-administrator"},
     {"source":  "git@github.com:hmcts/terraform-module-dynatrace-oneagent.git?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-automation-runbook-start-stop-vm?ref=master"}


### PR DESCRIPTION
### Change description ###
Pipeline seems to be failing because .git isn't in the source definition. Removing it to keep in line with other repo definitions


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
