### PR TITLE
Update pre-shared-infrastructure.json

### DIFF
--- a/terraform-infra-approvals/pre-shared-infrastructure.json
+++ b/terraform-infra-approvals/pre-shared-infrastructure.json
@@ -46,7 +46,8 @@
     {"type": "azurerm_private_link_service"},
     {"type": "azurerm_lb"},
     {"type": "azurerm_network_security_group"},
-    {"type": "azurerm_network_security_rule"}
+    {"type": "azurerm_network_security_rule"},
+    {"type": "azurerm_media_content_key_policy"}
   ],
   
   "module_calls": [


### PR DESCRIPTION
I want to be able to create a default content key policy that exists when AMS is stood up.

**Does this PR introduce a breaking change?**

```
[ ] Yes
[x] No
```
