### PR TITLE
PUB-2159 Updated PIP shared infra allow list

### DIFF
--- a/terraform-infra-approvals/pip-shared-infrastructures.json
+++ b/terraform-infra-approvals/pip-shared-infrastructures.json
@@ -3,7 +3,8 @@
     {"type": "random_password"},
     {"type": "azuread_application_password"},
     {"type": "azurerm_automation_account"},
-    {"type": "azurerm_api_management_subscription"}
+    {"type": "azurerm_api_management_subscription"},
+    {"type": "azurerm_identity_federated_credential"}
   ],
   "module_calls": [
     {"source":  "git@github.com:hmcts/cnp-module-automation-runbook-app-recycle?ref=master"},


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/PUB-2159

### Change description ###

Added azurerm_identity_federated_credential to the allow list for pip shared infras to create a federated identity to support the work going on between DTS and Crime.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change 
