### PR TITLE
Remove-ref-to-oracle-azure-infrastructure-terra

### DIFF
--- a/terraform-infra-approvals/libragob-shared-infrastructure.json
+++ b/terraform-infra-approvals/libragob-shared-infrastructure.json
@@ -69,9 +69,6 @@
   ],
   "module_calls": [
     {
-      "source": "git@github.com:hmcts/oracle-azure-infrastructure-terraform-modules.git//azure-vm?ref=0.0.58"
-    },
-    {
       "source": "./modules/azure-vm?ref=master"
     },
     {


### PR DESCRIPTION
### Jira link (if applicable)
DTSPO-15242


### Change description ###
Remove link to "oracle-azure-infrastructure-terraform-modules" as decommissioning legacy module

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
