### PR TITLE
Add HMI APIM Infrastructures to All Environments

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -25,3 +25,4 @@ prod:
   - repo: https://github.com/hmcts/darts-shared-infrastructure.git
   - repo: https://github.com/hmcts/darts-automation.git
   - repo: https://github.com/hmcts/pdda-shared-infrastructure.git
+  - repo: https://github.com/hmcts/hmi-apim-infrastructures.git


### PR DESCRIPTION
### Change description ###

Add HMI APIM Infrastructures to All Environments. PLEASE DO NOT MERGE THIS PR ONCE APPROVED. HMI team will merge it.

