### PR TITLE
Add pre-api to prod infra approvals

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -13,6 +13,7 @@ prod:
   - repo: https://github.com/hmcts/pip-publication-services.git
   - repo: https://github.com/hmcts/libragob-shared-infrastructure.git
   - repo: https://github.com/hmcts/sds-keda-infrastructure.git
+  - repo: https://github.com/hmcts/pre-api.git
   - repo: https://github.com/hmcts/pre-shared-infrastructure.git
   - repo: https://github.com/hmcts/pre-network.git
   - repo: https://github.com/hmcts/pre-vault.git


### PR DESCRIPTION
We've moved the APIm tf code from our shared-infra repo to our api repo

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
