### PR TITLE
juror: add ad admin

### DIFF
--- a/terraform-infra-approvals/juror-api.json
+++ b/terraform-infra-approvals/juror-api.json
@@ -1,5 +1,7 @@
 {
-  "resources": [],
+  "resources": [
+    {"type": "azurerm_postgresql_flexible_server_active_directory_administrator"}
+  ],
   "module_calls": [
     {"source":  "git@github.com:hmcts/terraform-module-sdp-db-user?ref=master"}
   ]


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###
add the admin azure resource provider into juror-api which will allow us to assign admin groups to our dbs based upon the juror groups https://github.com/hmcts/juror-api/pull/288

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
