### PR TITLE
Update organisations.groovy

### DIFF
--- a/jobdsl/organisations.groovy
+++ b/jobdsl/organisations.groovy
@@ -146,7 +146,7 @@ Closure githubOrg(Map args = [:]) {
                     strategyId(1)
                 }
                 traits << 'org.jenkinsci.plugins.github__branch__source.OriginPullRequestDiscoveryTrait' {
-                    strategyId(1)
+                    strategyId(2)
                 }
                 traits << 'org.jenkinsci.plugins.github__branch__source.ExcludeArchivedRepositoriesTrait' {
                 }


### PR DESCRIPTION
Disables PR build on every merge

Same functional change as CFT carried out in this PR https://github.com/hmcts/cnp-jenkins-config/pull/820

https://tools.hmcts.net/jira/browse/S28-3694



### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
