### PR TITLE
DTSPO-31965: approve Toffee key vault module branch

### DIFF
--- a/terraform-infra-approvals/sds-toffee-shared-infrastructure.json
+++ b/terraform-infra-approvals/sds-toffee-shared-infrastructure.json
@@ -5,7 +5,7 @@
   ],
   "module_calls": [
     {"source":  "git@github.com:hmcts/terraform-module-application-insights?ref=DTSPO-16829-prepare"},
-    {"source":  "git@github.com:hmcts/terraform-module-ai-services?ref=DTSPO-30612/optional-networking"}
+    {"source":  "git@github.com:hmcts/terraform-module-ai-services?ref=DTSPO-30612/optional-networking"},
+    {"source": "git@github.com:hmcts/cnp-module-key-vault?ref=DTSPO-31965/remove-jenkins-ptl-access"}
   ]
 }
-


### PR DESCRIPTION
Approve the temporary key vault module branch for sds-toffee-shared-infrastructure.