### PR TITLE
chore: add jenkinsfile for seed job

### DIFF
--- a/jobdsl/Jenkinsfile_seed
+++ b/jobdsl/Jenkinsfile_seed
@@ -1,0 +1,12 @@
+node {
+  checkout([$class: 'GitSCM',
+    branches: [[name: 'master']],
+    userRemoteConfigs: [[
+      url: 'https://github.com/hmcts/sds-jenkins-config.git',
+      credentialsId: 'hmcts-jenkins-cnp'
+    ]]
+  ])
+  jobDsl scriptText: readFile('jobdsl/organisations.groovy'),
+         removedJobAction: 'IGNORE',
+         removedViewAction: 'IGNORE'
+}


### PR DESCRIPTION
## 🔧 Regular change

> Complete this section for configuration changes, fixes, and general updates. Remove if not applicable.

### JIRA link (if applicable)

### Change description
- Add a Jenkinsfile for the seed job that will run on a schedule
- Will keep the list of allowed repos up-to-date throughout the day
- Credentials used are correct even though the say `cnp`