### PR TITLE
Updated repo for opal-file-handler

### DIFF
--- a/deployment-controls.yml
+++ b/deployment-controls.yml
@@ -79,7 +79,7 @@ repositories:
     deployment-enabled: true
   - repo: https://github.com/hmcts/opal-external-api.git
     deployment-enabled: true
-  - repo: https://github.com/hmcts/opal-file-handler.git
+  - repo: https://github.com/hmcts/opal-file-handler-service.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/opal-fines-service.git
     deployment-enabled: true


### PR DESCRIPTION
## 🚀 New repository / enabling deployments

> Complete this section **only** when adding a repository to `deployment-controls.yml`. Remove if not applicable.

### Repository being enabled for deployment
https://github.com/hmcts/opal-file-handler-service
