### PR TITLE
Add another missing module

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -55,6 +55,7 @@
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=master"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=fix-aad-grant"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=feat%2Fadd-storage-tier"},
+    {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=DTSPO-30107-additional-postgres-admins"},
     {"source":  "git@github.com:hmcts/terraform-module-dynatrace-oneagent.git?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-automation-runbook-start-stop-vm?ref=master"},
     {"source":  "git@github.com:hmcts/terraform-module-common-tags.git?ref=master"},


### PR DESCRIPTION
## 🔧 Regular change

`hmcts/terraform-module-postgresql-flexible?ref=DTSPO-30107-additional-postgres-admins` is missing also

### Change description

`hmcts/terraform-module-postgresql-flexible?ref=DTSPO-30107-additional-postgres-admins` is missing also
