### PR TITLE
DTSPO-33658: whitelist opal function app module

### DIFF
--- a/terraform-infra-approvals/opal-shared-infrastructure.json
+++ b/terraform-infra-approvals/opal-shared-infrastructure.json
@@ -11,6 +11,9 @@
   "module_calls": [
     {
       "source": "git@github.com:hmcts/terraform-module-virtual-machine.git?ref=master"
+    },
+    {
+      "source": "git@github.com:hmcts/cpp-module-terraform-azurerm-functionapp?ref=3d89c1287f3d8e2028f7d1ccfc87e51c66a27bd1"
     }
   ]
 }


### PR DESCRIPTION
## Why
Jenkins infra whitelist check fails for hmcts/opal-shared-infrastructure PR #140 due to a new module source not listed in terraform approvals:

- `git@github.com:hmcts/cpp-module-terraform-azurerm-functionapp?ref=3d89c1287f3d8e2028f7d1ccfc87e51c66a27bd1`

## What
Add that module source to `terraform-infra-approvals/opal-shared-infrastructure.json` under `module_calls`.